### PR TITLE
Add rejected_passwords/README.md

### DIFF
--- a/passwords/README.md
+++ b/passwords/README.md
@@ -4,7 +4,7 @@
 ## ミラーサイト
 [https://yokaipw.ddns.net/](https://yokaipw.ddns.net/)
 
-## 全パスワード
+## 全パスワード(zip)
 - [passwords.zip](https://yokaipw.ddns.net/files/passwords.zip)
 
 ## チェックサム

--- a/rejected_passwords/README.md
+++ b/rejected_passwords/README.md
@@ -1,0 +1,59 @@
+# PCE版 妖怪道中記 解析パスワードリスト
+「#隠しパスワード解析選手権」で解析されたパスワードを、収集・管理していくリポジトリです。
+
+## このフォルダについて
+Discord上のチャンネルで共有された、ハズレ判定されたパスワードを収集したものです。
+
+## ミラーサイト
+[https://yokaipw.ddns.net/](https://yokaipw.ddns.net/)
+
+## 全パスワード(txt)
+- [rpasswords.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords.txt)
+
+## チェックサム
+- [rpasswords.sha256](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords.sha256)
+
+## 各パスワード
+先頭1文字ごとに分割されたパスワード
+
+- [rpasswords\_A.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_A.txt)
+- [rpasswords\_B.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_B.txt)
+- [rpasswords\_C.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_C.txt)
+- [rpasswords\_D.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_D.txt)
+- [rpasswords\_E.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_E.txt)
+- [rpasswords\_F.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_F.txt)
+- [rpasswords\_G.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_G.txt)
+- [rpasswords\_H.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_H.txt)
+- [rpasswords\_I.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_I.txt)
+- [rpasswords\_J.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_J.txt)
+- [rpasswords\_K.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_K.txt)
+- [rpasswords\_L.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_L.txt)
+- [rpasswords\_M.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_M.txt)
+- [rpasswords\_N.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_N.txt)
+- [rpasswords\_O.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_O.txt)
+- [rpasswords\_P.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_P.txt)
+- [rpasswords\_Q.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_Q.txt)
+- [rpasswords\_R.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_R.txt)
+- [rpasswords\_S.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_S.txt)
+- [rpasswords\_T.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_T.txt)
+- [rpasswords\_U.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_U.txt)
+- [rpasswords\_V.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_V.txt)
+- [rpasswords\_W.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_W.txt)
+- [rpasswords\_X.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_X.txt)
+- [rpasswords\_Y.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_Y.txt)
+- [rpasswords\_Z.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_Z.txt)
+- [rpasswords\_1.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_1.txt)
+- [rpasswords\_2.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_2.txt)
+- [rpasswords\_3.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_3.txt)
+- [rpasswords\_4.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_4.txt)
+- [rpasswords\_5.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_5.txt)
+- [rpasswords\_6.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_6.txt)
+- [rpasswords\_7.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_7.txt)
+- [rpasswords\_8.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_8.txt)
+- [rpasswords\_9.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_9.txt)
+- [rpasswords\_0.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_0.txt)
+- [rpasswords\_!.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_!.txt)
+- [rpasswords\_-.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_-.txt)
+- [rpasswords\_..txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_..txt)
+- [rpasswords\_nmc.txt](https://raw.githubusercontent.com/kmikage/yokai-password/main/rejected_passwords/rpasswords_nmc.txt)
+


### PR DESCRIPTION
To close #15 
### Changes
- [passwords/README.md](https://github.com/kmikage/yokai-password/blob/main/passwords/README.md) を 元に [rejected_passwords/README.md](https://github.com/kmikage/yokai-password/blob/main/rejected_passwords/README.md) を追加
- [passwords/README.md](https://github.com/kmikage/yokai-password/blob/main/passwords/README.md) の password.zip のリンク部分にファイル形式を追加 (rejected_password/rpasswords.txt との兼ね合い)

表記など良くない点があったらコメントください～